### PR TITLE
feat(security): security bump and taking into account issue #137

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,6 +146,9 @@ jobs:
   image-scan:
     name: image-scan (${{ matrix.component }})
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write
     strategy:
       fail-fast: false
       matrix:
@@ -164,6 +167,22 @@ jobs:
           tags: ${{ matrix.component }}:scan
           no-cache: true
           pull: true
+
+      - name: Trivy report (SARIF)
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: ${{ matrix.component }}:scan
+          format: sarif
+          output: trivy-${{ matrix.component }}.sarif
+          vuln-type: os,library
+          severity: CRITICAL,HIGH
+          ignore-unfixed: true
+
+      - name: Upload Trivy SARIF
+        uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a # v4.36.3
+        with:
+          sarif_file: trivy-${{ matrix.component }}.sarif
+          category: trivy-${{ matrix.component }}
 
       - name: Scan with Trivy
         uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0

--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -12,6 +12,9 @@ RUN uv sync --frozen --no-dev --no-install-project
 COPY . .
 RUN uv sync --frozen --no-dev
 
+# Keeping Rust uv deps out of scans
+RUN rm -f /bin/uv /bin/uvx && rm -rf /root/.cache/uv
+
 COPY entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -19,8 +22,7 @@ RUN chown -R honeywatch:honeywatch /app
 
 USER honeywatch
 
-# Use the prebuilt venv directly at runtime. No `uv run` needed, which
-# avoids uv trying to init a cache dir at startup.
+# Use the prebuilt venv directly at runtime; avoids uv cache init at start.
 ENV PATH="/app/.venv/bin:$PATH"
 
 EXPOSE 5000

--- a/ingestor/Dockerfile
+++ b/ingestor/Dockerfile
@@ -10,6 +10,10 @@ RUN uv sync --frozen --no-dev --no-install-project
 COPY src/ src/
 RUN uv sync --frozen --no-dev
 
+# uv is build-only; runtime uses /app/.venv/bin directly. Dropping it keeps the
+# Rust deps vendored in the uv binary (quinn-proto et al) out of image scans.
+RUN rm -f /bin/uv /bin/uvx && rm -rf /root/.cache/uv
+
 ENV GEOIP_DATA_DIR=/data/geoip
 
 RUN useradd --create-home --shell /bin/bash ingestor \


### PR DESCRIPTION
Security scans were failing due to the `quinn-proto` rust library from within uv. Cleared it out after the last uv sync in the image.

Additionally, applied one of the suggestions from the #137 really good point on the third one!