### PR TITLE
Origins query optimization - removing distinct passwrods and usernames from the query.

### DIFF
--- a/api/openapi.json
+++ b/api/openapi.json
@@ -388,16 +388,6 @@
             "example": 42,
             "type": "integer"
           },
-          "distinct_passwords": {
-            "description": "Distinct passwords tried.",
-            "example": 96,
-            "type": "integer"
-          },
-          "distinct_usernames": {
-            "description": "Distinct usernames tried.",
-            "example": 18,
-            "type": "integer"
-          },
           "sessions": {
             "description": "Distinct sessions from this country.",
             "example": 137,
@@ -422,8 +412,6 @@
           "country",
           "country_code",
           "distinct_ips",
-          "distinct_passwords",
-          "distinct_usernames",
           "sessions",
           "success_rate",
           "successful"

--- a/api/src/routes/stats.py
+++ b/api/src/routes/stats.py
@@ -134,6 +134,14 @@ def stats_top_credentials(query_args: dict[str, Any]) -> list[TopCredentialDict]
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_countries(query_args: dict[str, Any]) -> CountriesDict:
     """Return the per-country attack leaderboard ranked by the chosen sort."""
+
+    # Origins polls these every 120s; the aggregates move slowly, so let the
+    # browser reuse them instead of re-running the scan on every poll.
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return countries.country_breakdown(
         get_db(),
         sort=query_args["sort"],
@@ -150,6 +158,14 @@ def stats_countries(query_args: dict[str, Any]) -> CountriesDict:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_asns(query_args: dict[str, Any]) -> list[CountryAsnDict]:
     """Return the top-N source networks (ASN / org) by session count."""
+
+    # Origins polls these every 120s; the aggregates move slowly, so let the
+    # browser reuse them instead of re-running the scan on every poll.
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return countries.country_asns(
         get_db(), country=query_args.get("country"), top_n=query_args["top_n"]
     )
@@ -276,6 +292,14 @@ def stats_country_detail(_path_args: dict[str, Any], a2: str) -> CountryDetailDi
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_ssh_clients(query_args: dict[str, Any]) -> list[SshClientDict]:
     """Return the top-N SSH client versions ranked by session count."""
+
+    # Origins polls these every 120s; the aggregates move slowly, so let the
+    # browser reuse them instead of re-running the scan on every poll.
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return clients.ssh_clients(get_db(), top_n=query_args["top_n"])
 
 
@@ -287,6 +311,14 @@ def stats_ssh_clients(query_args: dict[str, Any]) -> list[SshClientDict]:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_fingerprints(query_args: dict[str, Any]) -> list[FingerprintDict]:
     """Return the top-N SSH client public key fingerprints by distinct IP count."""
+
+    # Origins polls these every 120s; the aggregates move slowly, so let the
+    # browser reuse them instead of re-running the scan on every poll.
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return clients.fingerprints(get_db(), top_n=query_args["top_n"])
 
 

--- a/api/src/schemas/stats.py
+++ b/api/src/schemas/stats.py
@@ -122,14 +122,6 @@ class CountryRowResponse(BaseSchema):
             "example": 0.59,
         },
     )
-    distinct_usernames = fields.Int(
-        required=True,
-        metadata={"description": "Distinct usernames tried.", "example": 18},
-    )
-    distinct_passwords = fields.Int(
-        required=True,
-        metadata={"description": "Distinct passwords tried.", "example": 96},
-    )
 
 
 class CountriesResponse(BaseSchema):

--- a/api/src/services/stats/countries.py
+++ b/api/src/services/stats/countries.py
@@ -100,34 +100,22 @@ def country_breakdown(
         .subquery()
     )
 
-    # Group attempts by (country, username, password) before counting distinct values.
+    # One pass grouped by country.
     auth_cc = func.coalesce(GeoLocation.country_code, UNKNOWN_COUNTRY).label(
         "country_code"
     )
-    auth_pre = (
+    auth_agg = (
         select(
             auth_cc,
-            AuthAttempt.username,
-            AuthAttempt.password,
-            func.count().label("cnt"),
-            func.count().filter(AuthAttempt.success.is_(True)).label("succ"),
+            cast(func.count(), BigInteger).label("attempts"),
+            cast(func.count().filter(AuthAttempt.success.is_(True)), BigInteger).label(
+                "successful"
+            ),
         )
         .select_from(AuthAttempt)
         .join(Session, Session.id == AuthAttempt.session_id)
         .outerjoin(GeoLocation, GeoLocation.ip == Session.src_ip)
-        .group_by(auth_cc, AuthAttempt.username, AuthAttempt.password)
-        .subquery()
-    )
-
-    auth_agg = (
-        select(
-            auth_pre.c.country_code,
-            cast(func.sum(auth_pre.c.cnt), BigInteger).label("attempts"),
-            cast(func.sum(auth_pre.c.succ), BigInteger).label("successful"),
-            func.count(func.distinct(auth_pre.c.username)).label("distinct_usernames"),
-            func.count(func.distinct(auth_pre.c.password)).label("distinct_passwords"),
-        )
-        .group_by(auth_pre.c.country_code)
+        .group_by(auth_cc)
         .subquery()
     )
 
@@ -155,8 +143,6 @@ def country_breakdown(
             distinct_ips,
             attempts,
             successful,
-            func.coalesce(auth_agg.c.distinct_usernames, 0).label("distinct_usernames"),
-            func.coalesce(auth_agg.c.distinct_passwords, 0).label("distinct_passwords"),
         )
         .select_from(sess_agg)
         .outerjoin(auth_agg, auth_agg.c.country_code == sess_agg.c.country_code)
@@ -177,8 +163,6 @@ def country_breakdown(
                 "attempts": att,
                 "successful": r.successful,
                 "success_rate": round(r.successful / att * 100, 2) if att else None,
-                "distinct_usernames": r.distinct_usernames,
-                "distinct_passwords": r.distinct_passwords,
             }
         )
 

--- a/api/src/services/types.py
+++ b/api/src/services/types.py
@@ -158,8 +158,6 @@ class CountryRowDict(TypedDict):
     attempts: int
     successful: int
     success_rate: float | None
-    distinct_usernames: int
-    distinct_passwords: int
 
 
 class CountriesDict(TypedDict):

--- a/api/tests/test_stats.py
+++ b/api/tests/test_stats.py
@@ -457,8 +457,7 @@ def test_countries_breakdown_envelope(client: Any, seed_data: Any) -> None:
     assert us["attempts"] == 2
     assert us["successful"] == 0
     assert us["success_rate"] == 0.0
-    assert us["distinct_usernames"] == 2  # root, admin
-    assert us["distinct_passwords"] == 2  # password123, admin
+    assert "distinct_usernames" not in us, "dropped: no page renders it"
 
     unknown = _country_row(data, "??")
     assert unknown["country"] == "Unknown"

--- a/dashboard/src/api/generated/types.gen.ts
+++ b/dashboard/src/api/generated/types.gen.ts
@@ -190,14 +190,6 @@ export type CountryRowResponse = {
      */
     distinct_ips: number;
     /**
-     * Distinct passwords tried.
-     */
-    distinct_passwords: number;
-    /**
-     * Distinct usernames tried.
-     */
-    distinct_usernames: number;
-    /**
      * Distinct sessions from this country.
      */
     sessions: number;

--- a/dashboard/tests/unit/utils/countries.test.ts
+++ b/dashboard/tests/unit/utils/countries.test.ts
@@ -18,8 +18,6 @@ function country(over: Partial<CountryRowResponse>): CountryRowResponse {
     attempts: 0,
     successful: 0,
     success_rate: null,
-    distinct_usernames: 0,
-    distinct_passwords: 0,
     ...over,
   }
 }


### PR DESCRIPTION
it was including distinct usernames and password - legacy artifact; now we don't make any use of it so there is no need to make this operation that much computationally heavy