### PR TITLE
Smaller performance optimizations - additional postgres param + caching hardened.

### DIFF
--- a/api/src/routes/stats.py
+++ b/api/src/routes/stats.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from flask import after_this_request
+from flask import Response, after_this_request
 from flask_smorest import Blueprint, abort
 
 from src.extensions import get_db
@@ -77,6 +77,22 @@ stats_bp = Blueprint(
 )
 
 
+def _cache_for(seconds: int) -> None:
+    """Let clients reuse a SUCCESSFUL response for `seconds`.
+
+    The status guard is load-bearing. security_headers.py sets no-store for
+    status >= 400 with setdefault, and after_this_request callbacks run before
+    it, so assigning unconditionally here would win and let the shared nginx
+    cache replay a 500 to every viewer until it expired.
+    """
+
+    @after_this_request
+    def _set(response: Response) -> Response:  # pyright: ignore[reportUnusedFunction]
+        if response.status_code < 400:
+            response.headers["Cache-Control"] = f"public, max-age={seconds}"
+        return response
+
+
 @stats_bp.route("/totals")
 @stats_bp.doc(operationId="statsTotals")
 @stats_bp.response(200, TotalsResponse)
@@ -119,10 +135,7 @@ def stats_top_credentials(query_args: dict[str, Any]) -> list[TopCredentialDict]
 
     # Credentials polls every 30s, these are top-N aggregates over many
     # attempts. Two minutes doesn't matter much.
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return credentials.top_credentials(
         get_db(),
@@ -145,10 +158,7 @@ def stats_countries(query_args: dict[str, Any]) -> CountriesDict:
 
     # Origins polls these every 120s; the aggregates move slowly, so let the
     # browser reuse them instead of re-running the scan on every poll.
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return countries.country_breakdown(
         get_db(),
@@ -169,10 +179,7 @@ def stats_asns(query_args: dict[str, Any]) -> list[CountryAsnDict]:
 
     # Origins polls these every 120s; the aggregates move slowly, so let the
     # browser reuse them instead of re-running the scan on every poll.
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return countries.country_asns(
         get_db(), country=query_args.get("country"), top_n=query_args["top_n"]
@@ -186,10 +193,7 @@ def stats_asns(query_args: dict[str, Any]) -> list[CountryAsnDict]:
 def stats_auth_outcomes() -> AuthOutcomesDict:
     """Return the accept/reject split across all auth attempts."""
 
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return credentials.auth_outcomes(get_db())
 
@@ -212,10 +216,7 @@ def stats_outcomes(query_args: dict[str, Any]) -> OutcomeCountsDict:
 def stats_password_composition() -> PasswordCompositionDict:
     """Return the password length histogram + charset-class breakdown."""
 
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return credentials.password_composition(get_db())
 
@@ -229,10 +230,7 @@ def stats_password_composition() -> PasswordCompositionDict:
 def stats_passwords_by_length(query_args: dict[str, Any]) -> list[TopPasswordDict]:
     """Return the top-N passwords of a given length (histogram drill-down)."""
 
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return credentials.passwords_by_length(
         get_db(), query_args["length"], top_n=query_args["top_n"]
@@ -281,10 +279,7 @@ def stats_heatmap(query_args: dict[str, Any]) -> list[HeatmapPointDict]:
 def stats_map() -> MapDataDict:
     """Return one payload for the Overview map deck: choropleth + city markers."""
 
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return map_deck.map_data(get_db())
 
@@ -302,10 +297,7 @@ def stats_country_detail(_path_args: dict[str, Any], a2: str) -> CountryDetailDi
     if result is None:
         abort(404, message="Country not found")
 
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=300"
-        return response
+    _cache_for(300)
 
     return result
 
@@ -321,10 +313,7 @@ def stats_ssh_clients(query_args: dict[str, Any]) -> list[SshClientDict]:
 
     # Origins polls these every 120s; the aggregates move slowly, so let the
     # browser reuse them instead of re-running the scan on every poll.
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return clients.ssh_clients(get_db(), top_n=query_args["top_n"])
 
@@ -340,10 +329,7 @@ def stats_fingerprints(query_args: dict[str, Any]) -> list[FingerprintDict]:
 
     # Origins polls these every 120s; the aggregates move slowly, so let the
     # browser reuse them instead of re-running the scan on every poll.
-    @after_this_request
-    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
-        response.headers["Cache-Control"] = "public, max-age=120"
-        return response
+    _cache_for(120)
 
     return clients.fingerprints(get_db(), top_n=query_args["top_n"])
 

--- a/api/src/routes/stats.py
+++ b/api/src/routes/stats.py
@@ -116,6 +116,14 @@ def stats_top_countries(query_args: dict[str, Any]) -> list[TopCountryDict]:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_top_credentials(query_args: dict[str, Any]) -> list[TopCredentialDict]:
     """Return the top-N attempted credentials ranked by the chosen metric."""
+
+    # Credentials polls every 30s, these are top-N aggregates over many
+    # attempts. Two minutes doesn't matter much.
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return credentials.top_credentials(
         get_db(),
         by=query_args["by"],
@@ -177,6 +185,12 @@ def stats_asns(query_args: dict[str, Any]) -> list[CountryAsnDict]:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_auth_outcomes() -> AuthOutcomesDict:
     """Return the accept/reject split across all auth attempts."""
+
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return credentials.auth_outcomes(get_db())
 
 
@@ -197,6 +211,12 @@ def stats_outcomes(query_args: dict[str, Any]) -> OutcomeCountsDict:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_password_composition() -> PasswordCompositionDict:
     """Return the password length histogram + charset-class breakdown."""
+
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return credentials.password_composition(get_db())
 
 
@@ -208,6 +228,12 @@ def stats_password_composition() -> PasswordCompositionDict:
 @stats_bp.alt_response(500, "InternalServerError")
 def stats_passwords_by_length(query_args: dict[str, Any]) -> list[TopPasswordDict]:
     """Return the top-N passwords of a given length (histogram drill-down)."""
+
+    @after_this_request
+    def _cache(response: Any) -> Any:  # pyright: ignore[reportUnusedFunction]
+        response.headers["Cache-Control"] = "public, max-age=120"
+        return response
+
     return credentials.passwords_by_length(
         get_db(), query_args["length"], top_n=query_args["top_n"]
     )

--- a/api/tests/test_security_headers.py
+++ b/api/tests/test_security_headers.py
@@ -16,3 +16,30 @@ def test_openapi_json_uses_no_store(client: Any) -> None:
     response = client.get("/api/v1/openapi.json")
     assert response.status_code == 200
     assert "no-store" in response.headers.get("Cache-Control", "")
+
+
+def test_cached_stats_endpoint_sets_max_age(client: Any) -> None:
+    response = client.get("/api/v1/stats/auth-outcomes")
+    assert response.status_code == 200
+    assert "max-age=120" in response.headers.get("Cache-Control", "")
+
+
+def test_cached_stats_endpoint_error_stays_no_store(
+    app: Any, client: Any, monkeypatch: Any
+) -> None:
+    """An error must not inherit the endpoint's cache header.
+
+    nginx honours upstream Cache-Control and its cache is shared by every
+    viewer, so a cached 500 would be replayed to all of them until it expired.
+    """
+    from src.services.stats import credentials
+
+    def _boom(*_args: Any, **_kwargs: Any) -> None:
+        raise RuntimeError("simulated service failure")
+
+    monkeypatch.setattr(credentials, "auth_outcomes", _boom)
+    monkeypatch.setitem(app.config, "PROPAGATE_EXCEPTIONS", False)
+
+    response = client.get("/api/v1/stats/auth-outcomes")
+    assert response.status_code == 500
+    assert "no-store" in response.headers.get("Cache-Control", "")

--- a/dashboard/src/views/CredentialsView.vue
+++ b/dashboard/src/views/CredentialsView.vue
@@ -37,10 +37,10 @@
     type BarRow,
   } from '@/utils/credentials'
 
-  // Fast lenses (matrix rows/cols/pairs): 30s (matches endpoint Cache-Control);
-  // full-scan aggregates: 60s.
-  const POLL_MS = 30_000
-  const POLL_SLOW_MS = 60_000
+  // These endpoints send Cache-Control: max-age=120, so polling faster than that
+  // only re-reads the browser's own cache and never reaches the API. One value,
+  // matching the cache, instead of two that pretend to be quicker.
+  const POLL_MS = 120_000
   const MATRIX_USERS = 8
   // API max is 100 (validate.Range in common.py); HexMatrix reports actual
   // drawn count via @shown, so fetch conservatively.
@@ -65,13 +65,13 @@
   })
   const outcomesQ = useQuery({
     ...statsAuthOutcomesOptions(),
-    refetchInterval: POLL_SLOW_MS,
-    staleTime: POLL_SLOW_MS,
+    refetchInterval: POLL_MS,
+    staleTime: POLL_MS,
   })
   const compositionQ = useQuery({
     ...statsPasswordCompositionOptions(),
-    refetchInterval: POLL_SLOW_MS,
-    staleTime: POLL_SLOW_MS,
+    refetchInterval: POLL_MS,
+    staleTime: POLL_MS,
   })
 
   await Promise.all([

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -147,10 +147,14 @@ services:
       POSTGRES_API_PASSWORD: ${POSTGRES_API_PASSWORD:?POSTGRES_API_PASSWORD must be set}
       POSTGRES_INITDB_ARGS: >-
         -c password_encryption=scram-sha-256 -c log_connections=on -c log_disconnections=on -c log_statement=ddl -c shared_preload_libraries=pg_stat_statements -c shared_buffers=128MB -c work_mem=4MB -c max_connections=50 -c log_line_prefix='%t [%p]: [%l-1] user=%u,db=%d,app=%a,client=%h '
+    # Runtime tuning: INITDB_ARGS above only runs at cluster creation, so it
+    # cannot retune an existing volume. Command-line flags apply on every start.
     command:
       - postgres
       - -c
       - hba_file=/etc/postgresql/pg_hba.conf
+      - -c
+      - random_page_cost=1.1
     volumes:
       - postgres-data:/var/lib/postgresql/data
       - ./postgres/init.sh:/docker-entrypoint-initdb.d/00-roles.sh:ro,Z

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -26,6 +26,10 @@ services:
       POSTGRES_USER: ${POSTGRES_USER}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: ${POSTGRES_DB}
+    command:
+      - postgres
+      - -c
+      - random_page_cost=1.1
     volumes:
       - postgres-data:/var/lib/postgresql/data
     networks:

--- a/justfile
+++ b/justfile
@@ -46,6 +46,8 @@ pnpm *args:
     cd dashboard && pnpm {{args}}
 
 # Fast pytest against the dev postgres' test DB (`just dev` first).
+# A wall of alembic "Can't locate revision" errors means a sibling worktree
+# sharing this postgres migrated honeywatch_test: `just db test-reset`.
 test-api:
     cd api && POSTGRES_HOST=localhost POSTGRES_PORT="${POSTGRES_HOST_PORT:-5433}" POSTGRES_TEST_DB=honeywatch_test uv run --extra dev pytest -q
 

--- a/postgres/init.sql
+++ b/postgres/init.sql
@@ -1,5 +1,7 @@
 -- Per-app role split; only runs on initial PG init.
 
+CREATE EXTENSION IF NOT EXISTS pg_stat_statements;
+
 CREATE ROLE honeywatch_ingestor WITH LOGIN PASSWORD :'INGESTOR_PW';
 CREATE ROLE honeywatch_api      WITH LOGIN PASSWORD :'API_PW';
 

--- a/proxy/nginx.conf
+++ b/proxy/nginx.conf
@@ -36,11 +36,8 @@ http {
     proxy_read_timeout 30s;
     proxy_send_timeout 10s;
 
-    # Micro-cache for the read-only API: the dashboard polls identical stats
-    # queries every 10-30s from every viewer; a 10s cache collapses that to at
-    # most one upstream query per endpoint per interval, regardless of viewer
-    # count. Lives on the tmpfs mounted at /var/cache/nginx (read_only container).
-    proxy_cache_path /var/cache/nginx/api keys_zone=api_cache:4m max_size=32m inactive=60s;
+    # Collapses similar polls from every viewer into one query.
+    proxy_cache_path /var/cache/nginx/api keys_zone=api_cache:4m max_size=32m inactive=10m;
 
     limit_req_zone $binary_remote_addr zone=api:10m rate=30r/s;
     limit_req_zone $binary_remote_addr zone=docs:10m rate=10r/s;


### PR DESCRIPTION
There were some not really optimal caching situations where it wasn't properly aligned with the polling. For example, pulling aggregates every 30 seconds - for a dataset that is larger than half a milion sessions - kind of misses the point. Minute there and two minutes the other way really don't change much, so it's a move in this direction.